### PR TITLE
Add entrait test case

### DIFF
--- a/test_cases/Cargo.lock
+++ b/test_cases/Cargo.lock
@@ -1425,6 +1425,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "entrait"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c888ffada3dd9e9141898caf2a14e4eb4ac4dc75fee781daff48e10e8748b96"
+dependencies = [
+ "entrait_macros",
+ "implementation",
+]
+
+[[package]]
+name = "entrait_macros"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f5cf4882a5b01c602016994a0fb686fa38a2c8d220872738a4aed3adf5c8ca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1928,6 +1949,12 @@ dependencies = [
  "png",
  "scoped_threadpool",
 ]
+
+[[package]]
+name = "implementation"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9cd5b8cf68a1cda2eb0bdd7250e6ffa69edf485dda06dfb5e5a67a556e8db91"
 
 [[package]]
 name = "indexmap"
@@ -3070,6 +3097,7 @@ dependencies = [
  "chumsky",
  "diesel",
  "easy-ml",
+ "entrait",
  "trybuild",
  "typed-builder",
  "uom",

--- a/test_cases/Cargo.toml
+++ b/test_cases/Cargo.toml
@@ -15,6 +15,7 @@ axum-macros = "0.2.3"
 bevy = {version = "0.9.0-dev", features = ["nightly-error-messages"]}
 easy-ml = "1.8.1"
 typed-builder = "0.10.0"
+entrait = "0.4"
 
 [patch.crates-io]
 diesel = { git = "https://github.com/weiznich/diesel", rev = "958391a3e793e409d0a925e0cc2317726c2d84b2"}

--- a/test_cases/tests/entrait/missing_impl_deep.rs
+++ b/test_cases/tests/entrait/missing_impl_deep.rs
@@ -1,58 +1,22 @@
-struct Impl<T>(T);
+use entrait::*;
 
-trait T1 {
-    fn t1(&self);
-}
-
-fn f1(deps: &impl T2) {
+#[entrait(T1)]
+fn t1(deps: &impl T2) {
     deps.t2();
 }
 
-impl<T> T1 for Impl<T>
-where
-    Self: T2,
-{
-    fn t1(&self) {
-        f1(self)
-    }
-}
-
-trait T2 {
-    fn t2(&self);
-}
-
-fn f2(deps: &impl T3) {
+#[entrait(T2)]
+fn t2(deps: &impl T3) {
     deps.t3();
 }
 
-impl<T> T2 for Impl<T>
-where
-    Self: T3,
-{
-    fn t2(&self) {
-        f2(self)
-    }
-}
-
-trait T3 {
-    fn t3(&self);
-}
-
-impl<T> T3 for Impl<T>
-where
-    Self: T4,
-{
-    fn t3(&self) {
-        f3(self)
-    }
-}
-
-fn f3(deps: &impl T4) {}
+#[entrait(T3)]
+fn t3(deps: &impl T4) {}
 
 trait T4 {}
 
 fn main() {
-    let app = Impl(());
-    // Note: The reason this fails is that T4 is not implemented for Impl<T>:
+    let app = Impl::new(());
+    // Note: The reason this fails is that T4 is not implemented for entriat::Impl<T>:
     app.t1();
 }

--- a/test_cases/tests/entrait/missing_impl_deep.rs
+++ b/test_cases/tests/entrait/missing_impl_deep.rs
@@ -1,0 +1,58 @@
+struct Impl<T>(T);
+
+trait T1 {
+    fn t1(&self);
+}
+
+fn f1(deps: &impl T2) {
+    deps.t2();
+}
+
+impl<T> T1 for Impl<T>
+where
+    Self: T2,
+{
+    fn t1(&self) {
+        f1(self)
+    }
+}
+
+trait T2 {
+    fn t2(&self);
+}
+
+fn f2(deps: &impl T3) {
+    deps.t3();
+}
+
+impl<T> T2 for Impl<T>
+where
+    Self: T3,
+{
+    fn t2(&self) {
+        f2(self)
+    }
+}
+
+trait T3 {
+    fn t3(&self);
+}
+
+impl<T> T3 for Impl<T>
+where
+    Self: T4,
+{
+    fn t3(&self) {
+        f3(self)
+    }
+}
+
+fn f3(deps: &impl T4) {}
+
+trait T4 {}
+
+fn main() {
+    let app = Impl(());
+    // Note: The reason this fails is that T4 is not implemented for Impl<T>:
+    app.t1();
+}

--- a/test_cases/tests/entrait/missing_impl_deep.stderr
+++ b/test_cases/tests/entrait/missing_impl_deep.stderr
@@ -1,0 +1,26 @@
+error[E0599]: the method `t1` exists for struct `Impl<()>`, but its trait bounds were not satisfied
+  --> tests/entrait/missing_impl_deep.rs:57:9
+   |
+1  | struct Impl<T>(T);
+   | --------------
+   | |      |
+   | |      method `t1` not found for this struct
+   | doesn't satisfy `Impl<()>: T1`
+   | doesn't satisfy `Impl<()>: T2`
+...
+57 |     app.t1();
+   |         ^^ method cannot be called on `Impl<()>` due to unsatisfied trait bounds
+   |
+note: trait bound `Impl<()>: T2` was not satisfied
+  --> tests/entrait/missing_impl_deep.rs:13:11
+   |
+11 | impl<T> T1 for Impl<T>
+   |         --     -------
+12 | where
+13 |     Self: T2,
+   |           ^^ unsatisfied trait bound introduced here
+note: the following trait must be implemented
+  --> tests/entrait/missing_impl_deep.rs:20:1
+   |
+20 | trait T2 {
+   | ^^^^^^^^

--- a/test_cases/tests/entrait/missing_impl_deep.stderr
+++ b/test_cases/tests/entrait/missing_impl_deep.stderr
@@ -1,26 +1,21 @@
-error[E0599]: the method `t1` exists for struct `Impl<()>`, but its trait bounds were not satisfied
-  --> tests/entrait/missing_impl_deep.rs:57:9
-   |
-1  | struct Impl<T>(T);
-   | --------------
-   | |      |
-   | |      method `t1` not found for this struct
-   | doesn't satisfy `Impl<()>: T1`
-   | doesn't satisfy `Impl<()>: T2`
-...
-57 |     app.t1();
-   |         ^^ method cannot be called on `Impl<()>` due to unsatisfied trait bounds
-   |
-note: trait bound `Impl<()>: T2` was not satisfied
-  --> tests/entrait/missing_impl_deep.rs:13:11
-   |
-11 | impl<T> T1 for Impl<T>
-   |         --     -------
-12 | where
-13 |     Self: T2,
-   |           ^^ unsatisfied trait bound introduced here
-note: the following trait must be implemented
-  --> tests/entrait/missing_impl_deep.rs:20:1
-   |
-20 | trait T2 {
-   | ^^^^^^^^
+error[E0599]: the method `t1` exists for struct `entrait::Impl<()>`, but its trait bounds were not satisfied
+   --> tests/entrait/missing_impl_deep.rs:21:9
+    |
+21  |     app.t1();
+    |         ^^ method cannot be called on `entrait::Impl<()>` due to unsatisfied trait bounds
+    |
+   ::: $CARGO/implementation-0.1.3/src/lib.rs
+    |
+    | pub struct Impl<T>(T);
+    | ------------------
+    | |
+    | doesn't satisfy `entrait::Impl<()>: T1`
+    | doesn't satisfy `entrait::Impl<()>: T2`
+    |
+note: trait bound `entrait::Impl<()>: T2` was not satisfied
+   --> tests/entrait/missing_impl_deep.rs:4:19
+    |
+3   | #[entrait(T1)]
+    |           --
+4   | fn t1(deps: &impl T2) {
+    |                   ^^ unsatisfied trait bound introduced here

--- a/test_cases/tests/lib.rs
+++ b/test_cases/tests/lib.rs
@@ -1,6 +1,3 @@
-
-
-
 #[test]
 fn diesel() {
     let t = trybuild::TestCases::new();
@@ -25,7 +22,6 @@ fn axum() {
     t.compile_fail("tests/axum/*.rs");
 }
 
-
 #[test]
 fn bevy() {
     let t = trybuild::TestCases::new();
@@ -42,4 +38,10 @@ fn easy_ml() {
 fn typed_builder() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/typed_builder/*.rs");
+}
+
+#[test]
+fn entrait() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/entrait/*.rs");
 }


### PR DESCRIPTION
This test case describes a problem with deep-stack trait resolution: The root of the problem is a missing `T4` implementation, but the error message only mentions `T1` and `T2`. It should instead point to the root of the problem.

I made this test case without pulling in the entrait dependency, instead I just wrote explicitly what the macro does.